### PR TITLE
Minor changes to startup scripts

### DIFF
--- a/13-nfthotplug
+++ b/13-nfthotplug
@@ -2,8 +2,6 @@
 
 [ -n "$DEVICE" ] || exit 0
 
-[ "$ACTION" = ifup ] && {
+[ "$ACTION" = ifup ] && /etc/init.d/nftables enabled && {
   nft -f /etc/nftables.conf
-  
 }
-

--- a/nftables
+++ b/nftables
@@ -2,7 +2,7 @@
 # nftables start/restart based on Example script
 # Copyright (C) 2007 OpenWrt.org
  
-START=10
+START=19
 STOP=15
  
 start() {        


### PR DESCRIPTION
Update the start priority of the nftables firewall to 19 to match the built-in firewall.

For the hotplug script, check if the nftables service is enabled before running nft command.